### PR TITLE
Publish Dockerfiles to GHCR

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,112 @@
+name: Publish changed Dockerfiles to GHCR
+
+on:
+  push:
+    paths:
+      - "**/Dockerfile"
+  workflow_dispatch:
+    inputs:
+      dockerfile:
+        description: Dockerfile path to build and publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish changed images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish changed Dockerfiles
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            changed_files="$DOCKERFILE"
+          elif [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            changed_files="$(git ls-tree -r --name-only "$GITHUB_SHA")"
+          else
+            changed_files="$(git diff --name-only --diff-filter=AMR "$BEFORE_SHA" "$GITHUB_SHA")"
+          fi
+
+          mapfile -t dockerfiles < <(
+            printf '%s\n' "$changed_files" | awk '/(^|\/)Dockerfile$/'
+          )
+
+          if (( ${#dockerfiles[@]} == 0 )); then
+            echo "No added, modified, or renamed Dockerfiles to publish."
+            exit 0
+          fi
+
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          source_url="https://github.com/$GITHUB_REPOSITORY"
+          revision="$GITHUB_SHA"
+
+          for dockerfile in "${dockerfiles[@]}"; do
+            # A deleted Dockerfile can appear in the diff but has no image to build.
+            [[ -f "$dockerfile" ]] || continue
+
+            context="$(dirname "$dockerfile")"
+            relative_context="${context#images/}"
+
+            # The normal repository layout is images/<image>/<version>/Dockerfile.
+            # Additional subdirectories become part of the tag (for example,
+            # images/tool/latest/old/Dockerfile is published as tool:latest-old).
+            if [[ "$context" == images/* ]]; then
+              image_name="${relative_context%%/*}"
+              image_tag="${relative_context#"$image_name"}"
+              image_tag="${image_tag#/}"
+              [[ -n "$image_tag" ]] || image_tag="latest"
+              image_tag="${image_tag//\//-}"
+            else
+              # Support a Dockerfile outside images/ without requiring workflow edits.
+              image_name="${context//\//-}"
+              [[ "$image_name" != "." ]] || image_name="${GITHUB_REPOSITORY#*/}"
+              image_tag="latest"
+            fi
+
+            image_name="$(printf '%s' "$image_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+            image_tag="$(printf '%s' "$image_tag" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_.-]/-/g')"
+            image="ghcr.io/$owner/$image_name"
+
+            echo "Publishing $dockerfile as $image:$image_tag and $image:sha-$revision"
+            docker buildx build \
+              --file "$dockerfile" \
+              --tag "$image:$image_tag" \
+              --tag "$image:sha-$revision" \
+              --label "org.opencontainers.image.source=$source_url" \
+              --label "org.opencontainers.image.revision=$GITHUB_SHA" \
+              --label "org.opencontainers.image.url=$source_url" \
+              --label "org.opencontainers.image.title=$image_name" \
+              --provenance=mode=max \
+              --sbom=true \
+              --push \
+              "$context"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- GitHub Actions publishing of changed Dockerfiles to GitHub Container Registry
+  (GHCR), including source, SBOM, and provenance metadata.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
 # docker-images
-Collection of Dockerfiles
+
+Collection of Dockerfiles and a GitHub Actions publishing workflow.
+
+## Publishing to GHCR
+
+Pushing a new or changed file named `Dockerfile` starts the **Publish changed
+Dockerfiles to GHCR** workflow. It builds the Dockerfile using its containing
+directory as the build context and publishes the result to GitHub Container
+Registry (GHCR).
+
+For the repository's standard layout, use:
+
+```text
+images/<image-name>/<version>/Dockerfile
+```
+
+For example, a change to `images/fastp/0.23.3/Dockerfile` publishes:
+
+```text
+ghcr.io/yeolab/fastp:0.23.3
+ghcr.io/yeolab/fastp:sha-<full-commit-sha>
+```
+
+The version tag is convenient for normal use; the SHA tag identifies the exact
+source revision used to build it. For a strictly immutable reference, record
+and pull the image digest shown in GHCR. A Dockerfile directly under
+`images/<image-name>/` receives the `latest` tag. For a Dockerfile outside
+`images/`, the workflow derives a lowercase image name from its directory and
+uses the `latest` tag, so new locations do not require an edit to the workflow.
+
+Images include OCI source and revision labels plus BuildKit provenance and an
+SBOM. GitHub associates the resulting package with this repository; package
+visibility, access permissions, retention, and version deletion can be managed
+from the repository's **Packages** page.
+
+You can also run the workflow manually from the **Actions** page and provide
+one Dockerfile path; this is useful for rebuilding a single image without
+changing its source.
+
+The workflow uses the repository-scoped `GITHUB_TOKEN` and needs `packages:
+write`, already declared in the workflow. If organization policy prevents a
+publish, allow GitHub Actions to create packages for this repository or replace
+the token with an approved package-write token.
+
+## Pulling a Singularity/Apptainer image from GHCR
+
+Install [Apptainer](https://apptainer.org/) (or SingularityCE), then pull a
+published image directly from GHCR:
+
+```bash
+apptainer pull fastp_0.23.3.sif docker://ghcr.io/yeolab/fastp:0.23.3
+```
+
+For a strictly reproducible pull, replace the tag with the digest displayed on
+the GHCR package version:
+
+```bash
+apptainer pull fastp.sif docker://ghcr.io/yeolab/fastp@sha256:<image-digest>
+```
+
+For a private GHCR package, authenticate before pulling. With Apptainer, use a
+GitHub classic personal access token that has `read:packages` access:
+
+```bash
+export CR_PAT=ghp_your_token
+printf '%s' "$CR_PAT" | apptainer registry login --username YOUR_GITHUB_USER --password-stdin docker://ghcr.io
+apptainer pull fastp_0.23.3.sif docker://ghcr.io/yeolab/fastp:sha-<full-commit-sha>
+```
+
+Set the GHCR package to public from GitHub's **Packages** page if users should
+be able to pull it without credentials.


### PR DESCRIPTION
## Summary

- Publish added, modified, and renamed Dockerfiles to GitHub Container Registry.
- Assign image/version and commit-SHA tags with OCI source metadata, an SBOM, and provenance.
- Document Apptainer/Singularity pulls from GHCR, including private-package authentication.

## Validation

- YAML parsing
- Bash syntax check for the workflow publish script
- Representative image-name/tag derivation checks

The workflow uses the repository-scoped GITHUB_TOKEN with packages: write.