### PR TITLE
Fix ChipSeeker 1.32 image build

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -111,7 +111,6 @@ jobs:
               --label "org.opencontainers.image.url=$source_url" \
               --label "org.opencontainers.image.title=$image_name" \
               --provenance=mode=max \
-              --sbom=true \
               --push \
               "$context"
           done

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOCKERFILE: ${{ inputs.dockerfile }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
@@ -51,7 +52,11 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             changed_files="$DOCKERFILE"
           elif [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            changed_files="$(git ls-tree -r --name-only "$GITHUB_SHA")"
+            # A branch's first push has no predecessor SHA. Compare it with
+            # the default branch instead of treating every repository file as
+            # newly added.
+            base_sha="$(git merge-base "origin/$DEFAULT_BRANCH" "$GITHUB_SHA")"
+            changed_files="$(git diff --name-only --diff-filter=AMR "$base_sha" "$GITHUB_SHA")"
           else
             changed_files="$(git diff --name-only --diff-filter=AMR "$BEFORE_SHA" "$GITHUB_SHA")"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Updated the ChipSeeker 1.32 image's Jupyter base and fixed the Bioconductor
   data-package post-install hook so its R dependencies install successfully;
   the ChipSeeker package is now pinned to version 1.32.0.
+- Fixed first-push Dockerfile detection and removed BuildKit SBOM attachment
+  generation, which can exceed GitHub Container Registry's size limit for
+  large images; provenance remains enabled.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Updated the ChipSeeker 1.32 image's Jupyter base and fixed the Bioconductor
+  data-package post-install hook so its R dependencies install successfully;
+  the ChipSeeker package is now pinned to version 1.32.0.
+
 ### Added
 
 - GitHub Actions publishing of changed Dockerfiles to GitHub Container Registry

--- a/images/chipseeker/1.32/Dockerfile
+++ b/images/chipseeker/1.32/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM jupyter/datascience-notebook:hub-2.2.2
+FROM jupyter/datascience-notebook:latest
 
 ################## METADATA ######################
 
-LABEL base_image="jupyter/datascience-notebook:hub-2.2.2"
+LABEL base_image="jupyter/datascience-notebook:latest"
 LABEL version="1"
 LABEL software="R, Python3"
 LABEL software.version="1.32"
@@ -15,10 +15,6 @@ LABEL about.license="Artistic-2.0"
 LABEL about.tags=""
 LABEL about.publication="https://doi.org/10.1093/bioinformatics/btv145"
 
-################## MAINTAINER ######################
-MAINTAINER Brian Yee <brian.alan.yee@gmail.com>
-
-
 USER root
 
 COPY apt-packages.txt /tmp/apt-packages.txt
@@ -27,10 +23,44 @@ COPY conda-packages.txt /tmp/conda-packages.txt
 # Update image, install additional distro packages
 RUN apt-get update && xargs apt-get install -y < /tmp/apt-packages.txt
 
+# Bioconda data-package hooks need raw yq scalar output and a single R
+# architecture. Without those, current Conda transactions can attempt to load
+# a temporary "R.c~" executable as a second architecture.
+RUN for attempt in 1 2 3; do \
+      mamba install -y -c bioconda -c conda-forge bioconductor-data-packages && break; \
+      if [ "$attempt" = 3 ]; then exit 1; fi; \
+      mamba clean --all -y; \
+    done && \
+    sed -i \
+      -e 's/yq /yq -r /g' \
+      -e 's/R CMD INSTALL /R CMD INSTALL --no-multiarch /' \
+      /opt/conda/bin/installBiocDataPackage.sh
+
 # Install additional R packages from conda-forge using mamba
-RUN mamba install -y -c bioconda -c r -c conda-forge -c anaconda --file /tmp/conda-packages.txt
+RUN for attempt in 1 2 3; do \
+      mamba install -y -c bioconda -c r -c conda-forge -c anaconda --file /tmp/conda-packages.txt && break; \
+      if [ "$attempt" = 3 ]; then exit 1; fi; \
+      mamba clean --all -y; \
+    done
+
+# Older Bioconda data packages ship package-specific post-link scripts that
+# current mamba versions do not reliably execute. Run the required hooks in
+# dependency order, with the same single-architecture R workaround, then
+# confirm ChIPseeker can load.
+RUN set -eux; \
+    for hook in \
+      /opt/conda/bin/.bioconductor-genomeinfodbdata-post-link.sh \
+      /opt/conda/bin/.bioconductor-go.db-post-link.sh \
+      /opt/conda/bin/.bioconductor-do.db-post-link.sh \
+      /opt/conda/bin/.bioconductor-org.hs.eg.db-post-link.sh \
+      /opt/conda/bin/.bioconductor-txdb.hsapiens.ucsc.hg19.knowngene-post-link.sh \
+      /opt/conda/bin/.bioconductor-txdb.hsapiens.ucsc.hg38.knowngene-post-link.sh \
+      /opt/conda/bin/.bioconductor-ensdb.hsapiens.v75-post-link.sh; do \
+      sed -i -e '2i set -e' -e 's/R CMD INSTALL /R CMD INSTALL --no-multiarch /' "$hook"; \
+      PREFIX=/opt/conda PKG_NAME=bioconductor-data PKG_VERSION=manual PKG_BUILDNUM=0 bash "$hook"; \
+    done; \
+    Rscript -e 'library(ChIPseeker); stopifnot(as.character(packageVersion("ChIPseeker")) == "1.32.0")'
 
 RUN Rscript -e 'IRkernel::installspec(name = "r-chipseeker-1.32", displayname = "R (ChIPseeker-1.32)", user = FALSE)'
 
 USER $NB_UID
-

--- a/images/chipseeker/1.32/conda-packages.txt
+++ b/images/chipseeker/1.32/conda-packages.txt
@@ -1,4 +1,4 @@
-bioconductor-chipseeker
+bioconductor-chipseeker=1.32.0
 bioconductor-txdb.hsapiens.ucsc.hg38.knowngene
 bioconductor-ensdb.hsapiens.v75
 bioconductor-clusterprofiler


### PR DESCRIPTION
## Summary

- update the unavailable Jupyter base image and remove deprecated metadata
- work around Bioconda data-package post-link failures and install required annotation data in dependency order
- pin ChIPseeker to 1.32.0 and verify it loads during the image build

## Root cause

Legacy Bioconda data package hooks either failed while R was being upgraded or were skipped by current mamba, leaving required R annotation packages unavailable at runtime.

## Validation

- `docker build --platform linux/amd64 -t containers-chipseeker-build-check:1.32 images/chipseeker/1.32`
- runtime load of `ChIPseeker` confirmed version `1.32.0`
- verified the `r-chipseeker-1.32` Jupyter kernel is installed
- `git diff --check`